### PR TITLE
Add fingering support

### DIFF
--- a/client/public/musicxml/Ab_major_scale.musicxml
+++ b/client/public/musicxml/Ab_major_scale.musicxml
@@ -94,6 +94,11 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations>
+          <technical>
+            <fingering>1</fingering>
+          </technical>
+        </notations>
         </note>
       <note default-x="241.62" default-y="-55.00">
         <pitch>
@@ -105,6 +110,11 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations>
+          <technical>
+            <fingering>2</fingering>
+          </technical>
+        </notations>
         </note>
       <note default-x="361.07" default-y="-50.00">
         <pitch>
@@ -115,6 +125,11 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations>
+          <technical>
+            <fingering>3</fingering>
+          </technical>
+        </notations>
         </note>
       <note default-x="480.52" default-y="-45.00">
         <pitch>
@@ -126,6 +141,11 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations>
+          <technical>
+            <fingering>4</fingering>
+          </technical>
+        </notations>
         </note>
       </measure>
     <measure number="2" width="475.60">
@@ -139,6 +159,11 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations>
+          <technical>
+            <fingering>5</fingering>
+          </technical>
+        </notations>
         </note>
       <note default-x="123.75" default-y="-35.00">
         <pitch>
@@ -149,6 +174,10 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations>
+          <technical>
+          </technical>
+        </notations>
         </note>
       <note default-x="237.50" default-y="-30.00">
         <pitch>
@@ -159,6 +188,8 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations>
+        </notations>
         </note>
       <note default-x="351.25" default-y="-25.00">
         <pitch>

--- a/client/src/parser/MusicXML.tsx
+++ b/client/src/parser/MusicXML.tsx
@@ -127,6 +127,7 @@ export const parse = (xml: MusicXML.ScoreTimewise): Score => {
                                 let entryTies = entry.ties as {type: number}[];
                                 let staffNumber = entry.staff ? entry.staff : 1;
                                 let entrySlur: Slur | undefined;
+                                let entryFingering = '';
                                 let lyricsText: string | undefined;
 
                                 if (entry.notations && entry.notations.length > 0) {
@@ -137,15 +138,48 @@ export const parse = (xml: MusicXML.ScoreTimewise): Score => {
                                                 if (slur.type === 1) entrySlur = 'end';
                                             });
                                         }
+                                        if (notation.technicals) {
+                                            notation.technicals.forEach((technical: any) => {
+                                                console.log(technical.fingering);
+                                                if (technical.fingering) {
+                                                    if (technical.fingering.finger > -1) {
+                                                        entryFingering = `${technical.fingering.finger}`;
+                                                    }
+                                                }
+                                            });
+                                        }
                                     });
                                 }
                                 if (entry.lyrics) {
                                     let lyrics = entry.lyrics[0].lyricParts.find((lyrics: any) => lyrics._class === 'Text');
                                     if (lyrics) lyricsText = lyrics.data;
                                 }
+                                let setFingering = (value: number)=>{
+                                    if(!entry.notations){
+                                        entry.notations = [];
+                                    }
+                                    if((entry.notations as any[]).every(x=>x.technicals===undefined)){
+                                        entry.notations.push({technicals: []});
+                                    }
+                                    let technicals = (entry.notations as any[]).filter(x=>x.technicals!==undefined)[0].technicals as any[];
+                                    if(technicals.every(x=>x.fingering===undefined)){
+                                        technicals.push({fingering: {
+                                            substitution: false,
+                                            fontWeight: 0,
+                                            fontStyle: 0,
+                                            color: "#000000",
+                                            placement: 0,
+                                            alternate: false,
+                                        }});
+                                    }
+                                    technicals.filter(x=>x.fingering!==undefined)[0].fingering.finger = value;
+                                    (xml as any).revision = Math.random();
+                                }
                                 notes.push({
                                     time, duration: divisionsToNoteLength(entry.duration),
                                     midi: pitchToMidi(entry.pitch),
+                                    fingering: entryFingering,
+                                    setFingering,
                                     staff: staffNumber === 1 ? 'treble' : 'bass',
                                     attributes: {
                                         ties: entryTies ? entryTies.map(tie => tie.type === 0 ? Tie.Start : Tie.Stop) : [],

--- a/client/src/parser/Types.tsx
+++ b/client/src/parser/Types.tsx
@@ -33,6 +33,8 @@ export type Note = {
     time: number,
     duration: number,
     midi: number,
+    fingering: string,
+    setFingering: (x: number)=>void,
     staff: StaffType,
     attributes: {
         ties: Tie[],

--- a/client/src/util/Dialog.tsx
+++ b/client/src/util/Dialog.tsx
@@ -37,7 +37,9 @@ export const showPrompt = (title: string, body: any, buttonText1: string, button
                         {buttonText2}
                     </span>
                 </div>
-            </div>}};
+            </div>
+        }
+    };
 };
 
 const styleMap = {


### PR DESCRIPTION
Fingerings are now shown above noteheads
An export button was added to the convert page that allows edited works to be saved as musicxml files
An edit menu was added with edit options (currently only fingerings)
An edit button was added to the convert page so that the edit menu can be shown
A fingering edit mode was added which allows fingerings to be added to notes - clicking a notehead while in fingering edit mode will cause a pop-up menu to appear where the user can select the finger for the clicked note
A done button was added to the convert page that allows users to exit fingering edit mode