### PR TITLE
cumulative changes

### DIFF
--- a/client/src/contexts/Preferences.tsx
+++ b/client/src/contexts/Preferences.tsx
@@ -21,8 +21,14 @@ export type scalePreferenceOption = (typeof scalePreferenceOptions)[number];
 export const spacingPreferenceOptions = ['narrow', 'moderate', 'wide'] as const;
 export type spacingPreferenceOption = (typeof spacingPreferenceOptions)[number];
 
-export const noteHeadPreferenceOptions = ["●", "◼", "▲", "▼", "○", "☐", "△", "▽", "⊗", "⊠"] as const; // Previous symbols: ⨂, □
-export type noteHeadPreferenceOption = (typeof noteHeadPreferenceOptions)[number];
+export const naturalNoteHeadPreferenceOptions = ["●", "○"] as const; 
+export type naturalNoteHeadPreferenceOption = (typeof naturalNoteHeadPreferenceOptions)[number];
+
+export const sharpNoteHeadPreferenceOptions = ["▲", "△", "#"] as const;
+export type sharpNoteHeadPreferenceOption = (typeof sharpNoteHeadPreferenceOptions)[number];
+
+export const flatNoteHeadPreferenceOptions = ["▼", "▽", "b"] as const; 
+export type flatNoteHeadPreferenceOption = (typeof flatNoteHeadPreferenceOptions)[number];
 
 export const clefPreferenceOptions = ["WYSIWYP","Traditional"] as const;
 export type clefPreferenceOptions = (typeof clefPreferenceOptions)[number];
@@ -30,8 +36,11 @@ export type clefPreferenceOptions = (typeof clefPreferenceOptions)[number];
 export const measuresPerRowOptions = [1, 2, 3, 4, 5, 6] as const; // TODO: Consider using a slider
 export type measuresPerRowOption = (typeof measuresPerRowOptions)[number];
 
-export const accidentalTypeOptions = ['auto', 'sharp', 'flat'] as const;
+export const accidentalTypeOptions = ['auto', 'sharps', 'flats'] as const;
 export type accidentalTypeOption = (typeof accidentalTypeOptions)[number];
+
+export const lyricsFontSizeOptions = ['small', 'medium', 'large'] as const;
+export type lyricsFontSizeOption = (typeof lyricsFontSizeOptions)[number];
 
 export type state = {
     noteDurationColor: colorPreferenceOption;
@@ -40,12 +49,13 @@ export type state = {
     horizontalSpacing: spacingPreferenceOption;
     verticalSpacing: spacingPreferenceOption;
     noteScale: scalePreferenceOption;
-    naturalNoteShape: noteHeadPreferenceOption,
-    sharpNoteShape: noteHeadPreferenceOption;
-    flatNoteShape: noteHeadPreferenceOption;
+    naturalNoteShape: naturalNoteHeadPreferenceOption,
+    sharpNoteShape: sharpNoteHeadPreferenceOption;
+    flatNoteShape: flatNoteHeadPreferenceOption;
     clefSymbols: clefPreferenceOptions;
     measuresPerRow: measuresPerRowOption;
-    accidentalType: accidentalTypeOption
+    accidentalType: accidentalTypeOption;
+    lyricsFontSize: lyricsFontSizeOption
 };
 export type action = {
     type: "set";
@@ -64,7 +74,8 @@ let initialState: state = {
     flatNoteShape: '▼',
     clefSymbols: 'WYSIWYP',
     measuresPerRow: 4,
-    accidentalType: 'auto'
+    accidentalType: 'auto',
+    lyricsFontSize: 'small'
 };
 
 export const PreferencesContext = createContext(undefined! as [

--- a/client/src/pages/Convert.tsx
+++ b/client/src/pages/Convert.tsx
@@ -7,8 +7,9 @@ import {saveAs} from 'file-saver';
 import {useCurrentFileState} from '../contexts/CurrentFile';
 import MusicXML from 'musicxml-interfaces';
 import {
-    usePreferencesState, colorPreferenceOptions, scalePreferenceOptions,
-    spacingPreferenceOptions, noteHeadPreferenceOptions, measuresPerRowOptions, accidentalTypeOptions, clefPreferenceOptions
+    usePreferencesState, scalePreferenceOptions,
+    spacingPreferenceOptions, naturalNoteHeadPreferenceOptions, sharpNoteHeadPreferenceOptions, flatNoteHeadPreferenceOptions, measuresPerRowOptions,
+    accidentalTypeOptions, clefPreferenceOptions, lyricsFontSizeOptions
 } from '../contexts/Preferences';
 import jsPDF from 'jspdf';
 import canvg from 'canvg';
@@ -207,7 +208,7 @@ const Convert: React.FC<Props> = () => {
                     </div>
                 </>}
                 <div id="close" style={styles.sideBarTopOptions} onClick={() => {setShow(false);}}>
-                    Close ✕
+                    ✕
                 </div>
             </div>
 
@@ -220,6 +221,13 @@ const Convert: React.FC<Props> = () => {
                         </div>
 
                     </Expandable>
+                                      
+                    
+                        
+                        _________________________________________________
+                      Changes are made to the converted music file. To save in MusicXML format, select Export after editing. 
+                    
+
                 </Fragment>:<Fragment key="preferences">
 
                     <Expandable title="Staff Appearance">
@@ -261,14 +269,22 @@ const Convert: React.FC<Props> = () => {
                             <select value={preferences.verticalSpacing} onChange={
                                 (e) => {setPreferences({type: 'set', val: {verticalSpacing: e.target.value as any}});}
                             }>{spacingPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
-                        </div>
+                         </div>
+
+                         <div style={styles.line}>
+                             <div style={styles.name}>Lyrics Font Size</div>
+                             {/* deleted value and onchange */}
+                             <select value={preferences.lyricsFontSize} onChange={
+                                 (e) => { setPreferences({ type: 'set', val: { lyricsFontSize: e.target.value as any } }); }
+                             }>{lyricsFontSizeOptions.map(x => <option key={x}>{x}</option>)}</select>
+                         </div>
 
                     </Expandable>
 
                     <Expandable title="Note Appearance">
 
                         <div style={styles.line}>
-                            <div style={styles.name}>Accidental Type</div>
+                            <div style={styles.name}>Accidental Display</div>
                             <select value={preferences.accidentalType} onChange={
                                 (e) => {setPreferences({type: 'set', val: {accidentalType: e.target.value as any}});}
                             }>{accidentalTypeOptions.map(x => <option key={x}>{x}</option>)}</select>
@@ -287,7 +303,7 @@ const Convert: React.FC<Props> = () => {
                             {/* deleted value and onchange */}
                             <select value={preferences.naturalNoteShape} onChange={
                                 (e) => {setPreferences({type: 'set', val: {naturalNoteShape: e.target.value as any}});}
-                            }>{noteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
+                            }>{naturalNoteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
                         </div>
 
                         <div style={styles.line}>
@@ -295,7 +311,7 @@ const Convert: React.FC<Props> = () => {
                             {/* deleted value and onchange */}
                             <select value={preferences.sharpNoteShape} onChange={
                                 (e) => {setPreferences({type: 'set', val: {sharpNoteShape: e.target.value as any}});}
-                            }>{noteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
+                            }>{sharpNoteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
                         </div>
 
                         <div style={styles.line}>
@@ -303,21 +319,7 @@ const Convert: React.FC<Props> = () => {
                             {/* deleted value and onchange */}
                             <select value={preferences.flatNoteShape} onChange={
                                 (e) => {setPreferences({type: 'set', val: {flatNoteShape: e.target.value as any}});}
-                            }>{noteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
-                        </div>
-
-                        <div style={styles.line}>
-                            <div style={styles.name}>Notehead Color</div>
-                            <select value={preferences.noteSymbolColor} onChange={
-                                (e) => {setPreferences({type: 'set', val: {noteSymbolColor: e.target.value as any}});}
-                            }>{colorPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
-                        </div>
-
-                        <div style={styles.line}>
-                            <div style={styles.name}>Duration Color</div>
-                            <select value={preferences.noteDurationColor} onChange={
-                                (e) => {setPreferences({type: 'set', val: {noteDurationColor: e.target.value as any}});}
-                            }>{colorPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
+                            }>{flatNoteHeadPreferenceOptions.map(x => <option key={x}>{x}</option>)}</select>
                         </div>
 
                     </Expandable>

--- a/client/src/pages/Menu.tsx
+++ b/client/src/pages/Menu.tsx
@@ -36,13 +36,13 @@ const Menu: React.FC<Props> = () => {
     let [, setCurrentFile] = useCurrentFileState();
 
     let showError = (error: string) => {
-        setDialogState(Dialog.showMessage('An Error Occurred', error, 'Close', () => {
+        setDialogState(Dialog.showMessage('An Error Occurred', error, 'Cancel', () => {
             setDialogState(Dialog.close());
         }));
      };
 
     let deleteAllPrompt = () => {
-        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete all files?', 'Close', () => {
+        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete all converted files?', 'Cancel', () => {
             setDialogState(Dialog.close());
         }, 'Delete', () => {
             recentFiles.forEach(x=>{
@@ -54,7 +54,7 @@ const Menu: React.FC<Props> = () => {
         }));
     };
     let deleteSinglePrompt = (x: recentFile) => {
-        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete this file?', 'Close', () => {
+        setDialogState(Dialog.showPrompt('Delete Confirmation', 'Are you sure you want to delete this converted file?', 'Cancel', () => {
             setDialogState(Dialog.close());
         }, 'Delete', () => {
             let newRecentFiles = recentFiles.filter(y => y.id !== x.id);
@@ -289,8 +289,8 @@ const Menu: React.FC<Props> = () => {
     return (
         <Frame header="SNapp -&nbsp;Simplified&nbsp;Notation&nbsp;App&nbsp;for&nbsp;Sheet&nbsp;Music">
             {recentFiles === undefined ? null : <div style={styles.container}>
-                <div style={{ ...styles.item, flex: '1 0 auto' }} />
-                <div style={{ ...styles.item, maxWidth: '750px' }}>
+                <div style={{ ...styles.item, flex: '.37 0 auto' }} />
+                <div style={{ ...styles.item, maxWidth: '1200px' }}>
                     SNapp implements a simple and intuitive music notation known as What You See Is What You Play,
                     or WYSIWYP. With it, musicians can spend less time learning to read music and more time playing it!
                 </div>
@@ -302,7 +302,7 @@ const Menu: React.FC<Props> = () => {
                     <div style={{ ...styles.item, flex: '.35 0 auto' }} />
                 </> : <>
                         <div style={{ ...styles.item, flex: '.36 0 auto' }} />
-                        <div style={{ ...styles.item, fontSize: '28px', fontWeight: 'bolder' }}>Recent Files</div>
+                        <div style={{ ...styles.item, fontSize: '28px', fontWeight: 'bolder' }}>files already converted from MusicXML</div>
                         <div style={{ ...styles.item, flex: '.08 0 auto' }} />
                         <div style={{ ...styles.item, ...styles.recentFiles }}>
                             <div style={{ ...styles.recentFilesInner }}>
@@ -327,10 +327,8 @@ const Menu: React.FC<Props> = () => {
                         <div style={{ ...styles.item, flex: '.24 0 auto' }} />
                     </>}
                 <div style={styles.item}>
-                    <span id="button-upload" style={styles.link}>
-                        <img src={svg} style={styles.icon} alt="" />
-                        Open MusicXML File
-                        <input style={styles.fileInput} type="file" title="Click to upload" accept=".musicxml,.mxl,.xml" onChange={(e) => { uploadFile(e); }}></input>
+                    <span id="button-upload" style={styles.link}>                        Convert another MusicXML File
+                        <input style={styles.fileInput} type="file" title="Convert another MusicXML file" accept=".musicxml,.mxl,.xml" onChange={(e) => { uploadFile(e); }}></input>
                     </span>
                 </div>
                 {installHandle===undefined?null:<>
@@ -370,7 +368,7 @@ const styleMap = {
         left: 'auto',
         height: 'auto',
         marginLeft: '50%',
-        width: '70%',
+        width: '80%',
         transform: 'translate(-50%,0px)',
         textAlign: 'center',
         fontSize: '21px',
@@ -383,12 +381,12 @@ const styleMap = {
         width: '340px',
         height: '100%',
         cursor: 'pointer',
-        opacity: 0,
+        opacity: 0
     },
     recentFiles: {
         color: '#31B7D6',
-        maxWidth: '750px',
-        height: '250px',
+        maxWidth: '1200px',
+        height: '400px',
         borderRadius: '10px',
         border: '2px solid #BBBBBB',
         padding: '5px',
@@ -404,11 +402,11 @@ const styleMap = {
     recentFilesItem: {
         display: 'flex',
         width: 'calc(100% - 10px)',
-        marginTop: '20px',
+        marginTop: '1px',
         marginLeft: '5px',
         marginRight: '5px',
         lineHeight: '40px',
-        fontSize: '24px',
+        fontSize: '22px',
         position: 'relative',
         height: '40px',
         whiteSpace: 'nowrap',

--- a/client/src/parser/MusicXML.tsx
+++ b/client/src/parser/MusicXML.tsx
@@ -219,7 +219,8 @@ export const parse = (xml: MusicXML.ScoreTimewise): Score => {
                             try {
                                 part.keySignatures.push({
                                     measure: measureNumber,
-                                    fifths: entry.keySignatures[0].fifths
+                                    fifths: entry.keySignatures[0].fifths,
+                                    mode: entry.keySignatures[0].mode
                                 });
                             } catch (e) {
                                 console.error('Failed to parse key signature', entry.keySignatures[0]);
@@ -315,7 +316,7 @@ export const parse = (xml: MusicXML.ScoreTimewise): Score => {
     // handle unprovided signatures
     tracks.forEach(track => {
         // add default values for key signatures if it is not provided.
-        if (track.keySignatures.length === 0) track.keySignatures.push({measure: 0, fifths: 0});
+        if (track.keySignatures.length === 0) track.keySignatures.push({measure: 0, fifths: 0, mode: ''});
 
         if (track.timeSignatures.length === 0) {
             if (track.measures.length === 1) {

--- a/client/src/parser/Types.tsx
+++ b/client/src/parser/Types.tsx
@@ -54,7 +54,8 @@ export type TimeSignature = {
 
 export type KeySignature = {
     measure: number,
-    fifths: number
+    fifths: number,
+    mode: any
 };
 
 // Tracks and scores


### PR DESCRIPTION
Summary of Changes
Change various text strings:
     on Convert Page:
           change "Accidental type" to "Accidental display"
            change names of choices for accidentals to "sharps" and "flats" (add s)
            on Preferences, change "Close" to "X"
            add text to Edit side menu advising of Export
        on Main Page:
              change "Close" to "Cancel" on popups
              change "Recent files" to "Files already converted from MusicXML"
              change "upload Music XML file" to "Convert another MusicXML file" and remove icon
              change file list deletion messages to "Are you sure ... converted file"
              adjust the overall display of elements:
                    reduce space between header and text
                     widen the text
                     widen the file list
                     increase the height of the file list
                     reduce the height and font size of each file list entry
Functional changes
     Disable the note color preference by removing from side bar
     Create separate lists of noteheads for naturals, flats, and sharps
     Add new noteheads in traditional format for sharps (#) and flats (b)
     Change Accidental "auto" function to choose sharps or flats based on key signature
     Change the Title area to
            include the key signature
             show the first three credits in the MusicXML file (which may include the title)
        Add a new Staff Preference to select the font size for lyrics  
